### PR TITLE
CORE-450: Update to use ccdp-github-action bot for release

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Set git config
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "147416134+cdp-github-action[bot]@users.noreply.github.com"
+          git config user.email "cdp-github-action[bot]"
 
       - run: npm run release
         env:


### PR DESCRIPTION
`cdp-github-action` added to branch protection to allow bypass

<img width="763" alt="Screenshot 2025-06-17 at 10 14 23" src="https://github.com/user-attachments/assets/536fd843-7d01-47f8-a38f-47de7e0e7840" />
