### PR TITLE
Core 1155 update exports

### DIFF
--- a/.changeset/solid-parts-battle.md
+++ b/.changeset/solid-parts-battle.md
@@ -1,0 +1,9 @@
+---
+'@defra/hapi-secure-context': minor
+'@defra/catbox-dynamodb': minor
+'@defra/cdp-auditing': minor
+'@defra/hapi-tracing': minor
+'@defra/cdp-metrics': minor
+---
+
+Add vitest globals

--- a/.changeset/tasty-toys-march.md
+++ b/.changeset/tasty-toys-march.md
@@ -1,0 +1,6 @@
+---
+'@defra/cdp-validation-kit': minor
+---
+
+Export nested constants at root
+Add vitest globals

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ your `package.json` file, as they are already included in the root `package.json
 ## Testing your changes
 
 To test your changes in this repo in a local consuming codebase, `npm link` is your friend here. Have a read
-of https://docs.npmjs.com/cli/v9/commands/npm-link
+of https://docs.npmjs.com/cli/v9/commands /npm-link
 
 ## Not releasing
 

--- a/ci/release-it.sh
+++ b/ci/release-it.sh
@@ -15,7 +15,7 @@ else
   echo "Tag does not exist — running release-it for $tag..."
   (
     cd "$pkg"
-    npx release-it@19.0.3 --no-increment --ci || echo "Release-it failed for $tag"
+    npx release-it@19.0.4 --no-increment --ci || echo "Release-it failed for $tag"
   )
 fi
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
 import neostandard from 'neostandard'
 
 export default neostandard({
-  env: ['node'],
+  env: ['node', 'vitest'],
   ignores: [...neostandard.resolveIgnoresFromGitignore()],
   noJsx: true,
   noStyle: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -3499,18 +3499,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.10.0"
-      }
-    },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
@@ -6908,18 +6896,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/jiti": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
-      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/joi": {
       "version": "17.13.3",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
@@ -9173,15 +9149,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -9773,7 +9740,7 @@
     },
     "packages/cdp-validation-kit": {
       "name": "@defra/cdp-validation-kit",
-      "version": "0.48.0",
+      "version": "0.50.0",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/packages/catbox-dynamodb/src/dynamodb.test.js
+++ b/packages/catbox-dynamodb/src/dynamodb.test.js
@@ -1,11 +1,10 @@
-import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { CatboxDynamoDB } from './dynamodb'
 import {
   DynamoDBClient,
   PutItemCommand,
   DeleteItemCommand,
   DescribeTableCommand
 } from '@aws-sdk/client-dynamodb'
-import { CatboxDynamoDB } from './dynamodb'
 
 vi.mock('@aws-sdk/client-dynamodb', () => {
   return {

--- a/packages/cdp-auditing/src/auditing.test.js
+++ b/packages/cdp-auditing/src/auditing.test.js
@@ -1,8 +1,7 @@
-import { test, describe, expect, afterEach, beforeEach } from 'vitest'
-import { audit, enableAuditing, setAuditLogger } from './auditing.js'
-
-import { auditLoggerConfig } from './audit-logger-config.js'
 import pino from 'pino'
+
+import { audit, enableAuditing, setAuditLogger } from './auditing.js'
+import { auditLoggerConfig } from './audit-logger-config.js'
 
 export class TestPinoDestination {
   messages = []

--- a/packages/cdp-metrics/README.md
+++ b/packages/cdp-metrics/README.md
@@ -86,7 +86,6 @@ request.metrics().timer('dbFetch', async () => fetchUsers())
 In your tests, mock the internal aws-embedded-metrics methods to verify emitted metrics:
 
 ```js
-import { vi } from 'vitest'
 import * as embedded from 'aws-embedded-metrics'
 
 vi.spyOn(embedded, 'createMetricsLogger').mockImplementation(() => ({

--- a/packages/cdp-metrics/src/metrics-helper.test.js
+++ b/packages/cdp-metrics/src/metrics-helper.test.js
@@ -1,4 +1,3 @@
-import { describe, test, expect, beforeEach, vi } from 'vitest'
 import { MetricsHelper } from './metrics-helper.js'
 
 // Mock the entire aws-embedded-metrics module

--- a/packages/cdp-metrics/src/metrics.test.js
+++ b/packages/cdp-metrics/src/metrics.test.js
@@ -1,4 +1,3 @@
-import { describe, test, expect, vi, beforeEach } from 'vitest'
 import * as metricsModule from './metrics.js'
 
 const mockHelperInstance = {

--- a/packages/cdp-validation-kit/src/constants/build-memory-validation.test.js
+++ b/packages/cdp-validation-kit/src/constants/build-memory-validation.test.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { describe, test, expect } from 'vitest'
+
 import { buildMemoryValidation } from './build-memory-validation.js'
 import { ecsCpuToMemoryOptionsMap } from './ecs-cpu-to-memory-options-map.js'
 

--- a/packages/cdp-validation-kit/src/constants/ecs-cpu-to-memory-options-map.test.js
+++ b/packages/cdp-validation-kit/src/constants/ecs-cpu-to-memory-options-map.test.js
@@ -1,5 +1,4 @@
 import { ecsCpuToMemoryOptionsMap } from './ecs-cpu-to-memory-options-map'
-import { describe, test, expect } from 'vitest'
 
 describe('ecsCpuToMemoryMap', () => {
   test('Cpu of 8192 should only allows memory in increments of 4gb', () => {

--- a/packages/cdp-validation-kit/src/constants/memory-range.test.js
+++ b/packages/cdp-validation-kit/src/constants/memory-range.test.js
@@ -1,4 +1,3 @@
-import { describe, test, expect } from 'vitest'
 import { memoryRange } from './memory-range'
 
 describe('#memoryRange', () => {

--- a/packages/cdp-validation-kit/src/constants/scopes.js
+++ b/packages/cdp-validation-kit/src/constants/scopes.js
@@ -1,13 +1,13 @@
+/* @type {Record<string, string>} */
 const scopes = {
   admin: 'permission:admin',
-  tenant: 'permission:tenant',
-  serviceOwner: 'permission:serviceOwner',
-  externalTest: 'permission:externalTest',
   breakGlass: 'permission:breakGlass',
-  restrictedTechPython: 'permission:restrictedTechPython',
+  canGrantBreakGlass: 'permission:canGrantBreakGlass',
+  externalTest: 'permission:externalTest',
   restrictedTechPostgres: 'permission:restrictedTechPostgres',
-  canGrantProdAccess: 'permission:canGrantProdAccess',
-  prodAccess: 'permission:prodAccess',
+  restrictedTechPython: 'permission:restrictedTechPython',
+  serviceOwner: 'permission:serviceOwner',
+  tenant: 'permission:tenant',
   testAsTenant: 'permission:testAsTenant'
 }
 

--- a/packages/cdp-validation-kit/src/validations.js
+++ b/packages/cdp-validation-kit/src/validations.js
@@ -7,6 +7,10 @@ import {
   environmentsExceptForProd
 } from './constants/environments.js'
 
+export { scopes } from './constants/scopes.js'
+export { statusCodes } from './constants/status-codes.js'
+export { entityTypes, entitySubTypes } from './constants/entities.js'
+
 const environmentValidation = Joi.string()
   .valid(...Object.values(environments))
   .required()
@@ -134,8 +138,8 @@ export {
   migrationVersionValidation,
   repositoryNameValidation,
   runIdValidation,
-  teamValidation,
   teamIdValidation,
+  teamValidation,
   templateBranchNameValidation,
   templateTypeValidation,
   userIdValidation,

--- a/packages/cdp-validation-kit/src/validations.test.js
+++ b/packages/cdp-validation-kit/src/validations.test.js
@@ -1,4 +1,3 @@
-import { describe, test, expect } from 'vitest'
 import {
   currentEnvironmentValidation,
   environmentExceptForProdValidation,

--- a/packages/hapi-secure-context/src/get-trust-store-certs.test.js
+++ b/packages/hapi-secure-context/src/get-trust-store-certs.test.js
@@ -1,4 +1,3 @@
-import { describe, test, expect } from 'vitest'
 import { getTrustStoreCerts } from './get-trust-store-certs.js'
 
 describe('#getTrustStoreCerts', () => {

--- a/packages/hapi-secure-context/src/sercure-context.test.js
+++ b/packages/hapi-secure-context/src/sercure-context.test.js
@@ -1,6 +1,6 @@
-import { vi, beforeEach, expect, describe, test } from 'vitest'
-import { secureContext } from './secure-context.js'
 import tls from 'node:tls'
+
+import { secureContext } from './secure-context.js'
 
 describe('#secure-context', () => {
   const originalSecureContext = tls.createSecureContext

--- a/packages/hapi-tracing/src/tracing.test.js
+++ b/packages/hapi-tracing/src/tracing.test.js
@@ -1,4 +1,3 @@
-import { describe, test, expect, afterEach, beforeEach } from 'vitest'
 import { Server } from '@hapi/hapi'
 
 import { tracing, withTraceId } from './tracing.js'


### PR DESCRIPTION
- Export nested constants in validation kit
- Add `vitest` globals and remove explicitly imported `vitest` work
- Uncommitted package lock changes