### PR TITLE
Core 1155 update exports part ii

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,20 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
-  "commit": false,
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "defra/cdp-libraries" }
+  ],
+  "commit": true,
   "fixed": [],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "ignore": []
+  "ignore": [],
+  "release-it": {
+    "github": {
+      "release": true,
+      "releaseNotes": "cat CHANGELOG.md | sed -n '/^## /{n; :a; /^## /q; p; n; ba}'"
+    }
+  }
 }

--- a/.changeset/six-numbers-obey.md
+++ b/.changeset/six-numbers-obey.md
@@ -1,0 +1,5 @@
+---
+'@defra/hapi-tracing': patch
+---
+
+Bump package to test monorepo release functionaxlity

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ to simply create and manage CDP packages, ensuring consistency and ease of use a
 - [Testing your changes](#testing-your-changes)
 - [Not releasing](#not-releasing)
 - [Releasing](#releasing)
+- [Detailed instructions](#detailed-instructions)
 - [Changesets](#changesets)
 - [Release it](#release-it)
 
@@ -63,11 +64,14 @@ npm install
 The following tools are available for free from the root of `cdp-libraries`. You do not need to install these in
 your `package.json` file, as they are already included in the root `package.json`:
 
-- `vitest` - for running tests
-- `neostandard` - for linting code
-- `release-it` - for managing releases
-- `prettier` - for code formatting
-- `husky` - for managing git hooks
+| Tool          | Purpose                           |
+| ------------- | --------------------------------- |
+| `changesets`  | npm versioning and publishing     |
+| `husky`       | managing git hooks                |
+| `neostandard` | linting code                      |
+| `prettier`    | code formatting                   |
+| `release-it`  | managing GitHub releases and tags |
+| `vitest`      | running tests                     |
 
 ## Testing your changes
 
@@ -86,20 +90,25 @@ changeset. This is usually documentation or items in the `root` that do not need
 
 ## Releasing
 
-TL;DR: Releasing a new version of a package is as simple as running `npm run changeset` in root directory and merging a PR.
+TL;DR: Releasing a new version of a package is as simple as running `npm run changeset` in root directory and merging a
+PR.
 
-- Developer writes changeset
-- Chooses correct bump for changes
-- CI does everything else. Versions, tags, releases and publishes
+1. Commit your work
+1. `npm run changeset` and answer questions
+1. Push work and raise a PR
+1. Get PR reviewed and approved, then merge
+1. CI does everything else. Versions, tags, releases and publishes
 
-Read on for detailed instructions. Releasing to `npm` and tagging on `GitHub` is done using
-the [changeset](https://github.com/changesets/changesets) and [release-it](https://github.com/release-it/release-it)
-tools, which is configured in the root of the workspace. This is super simple and all you need to do is:
+## Detailed instructions
+
+Releasing to `npm` and tagging on `GitHub` is done using the [changeset](https://github.com/changesets/changesets)
+and [release-it](https://github.com/release-it/release-it) tools, which are
+configured in the root of the workspace. This is super simple and all you need to do is:
 
 After you have commited your work and are ready to release a new version of your package:
 
 - Run `npm run changeset` to create a new changeset
-- Commit the changeset file that was created in the `.changeset` directory
+- `git add .changeset` commit the changeset file that was created in the `.changeset` directory
 - Raise a PR with the changes you want to release
 - Wait for `status required checks` to pass
 - Get the PR reviewed and approved by at least one other developer

--- a/packages/catbox-dynamodb/package.json
+++ b/packages/catbox-dynamodb/package.json
@@ -46,8 +46,7 @@
     },
     "github": {
       "release": true,
-      "releaseName": "Released catbox-dynamodb ${version}",
-      "releaseNotes": "echo ''"
+      "releaseName": "Released catbox-dynamodb ${version}"
     },
     "git": {
       "commitMessage": "Tagged catbox-dynamodb ${version}",

--- a/packages/cdp-auditing/package.json
+++ b/packages/cdp-auditing/package.json
@@ -46,8 +46,7 @@
     },
     "github": {
       "release": true,
-      "releaseName": "Released cdp-auditing ${version}",
-      "releaseNotes": "echo ''"
+      "releaseName": "Released cdp-auditing ${version}"
     },
     "git": {
       "commitMessage": "Tagged cdp-auditing ${version}",

--- a/packages/cdp-metrics/package.json
+++ b/packages/cdp-metrics/package.json
@@ -50,8 +50,7 @@
     },
     "github": {
       "release": true,
-      "releaseName": "Release cdp-metrics ${version}",
-      "releaseNotes": "echo ''"
+      "releaseName": "Release cdp-metrics ${version}"
     },
     "git": {
       "commitMessage": "Tagged cdp-metrics ${version}",

--- a/packages/cdp-validation-kit/package.json
+++ b/packages/cdp-validation-kit/package.json
@@ -47,8 +47,7 @@
     },
     "github": {
       "release": true,
-      "releaseName": "Release cdp-validation-kit ${version}",
-      "releaseNotes": "echo ''"
+      "releaseName": "Release cdp-validation-kit ${version}"
     },
     "git": {
       "commitMessage": "Tagged cdp-validation-kit ${version}",

--- a/packages/hapi-secure-context/package.json
+++ b/packages/hapi-secure-context/package.json
@@ -45,8 +45,7 @@
     },
     "github": {
       "release": true,
-      "releaseName": "Released hapi-secure-context ${version}",
-      "releaseNotes": "echo ''"
+      "releaseName": "Released hapi-secure-context ${version}"
     },
     "git": {
       "commitMessage": "Tagged hapi-secure-context ${version}",

--- a/packages/hapi-tracing/package.json
+++ b/packages/hapi-tracing/package.json
@@ -45,8 +45,7 @@
     },
     "github": {
       "release": true,
-      "releaseName": "Released hapi-tracing ${version}",
-      "releaseNotes": "echo ''"
+      "releaseName": "Released hapi-tracing ${version}"
     },
     "git": {
       "commitMessage": "Tagged hapi-tracing ${version}",

--- a/packages/hapi-tracing/src/tracing.test.js
+++ b/packages/hapi-tracing/src/tracing.test.js
@@ -3,7 +3,7 @@ import { Server } from '@hapi/hapi'
 import { tracing, withTraceId } from './tracing.js'
 
 describe('#tracing and #withTraceId', () => {
-  const mockTraceId = 'mock-trace-id-123'
+  const mockTraceId = 'mock-trace-id-1234'
   let server
 
   beforeEach(async () => {
@@ -154,8 +154,8 @@ describe('#tracing and #withTraceId', () => {
           const result = withTraceId('x-trace-id', mockHeaders)
           expect(result).toEqual({
             existingHeader: 'value',
-            'x-cdp-request-id': 'mock-trace-id-123',
-            'x-trace-id': 'mock-trace-id-123'
+            'x-cdp-request-id': mockTraceId,
+            'x-trace-id': mockTraceId
           })
 
           return h.response({ message: 'success' }).code(200)


### PR DESCRIPTION
- Use changesets/changelog-github
- Extract text from changelog and put into release ntoes
- Centralise release it releaseNotes config
- Update docs
- Manually bump package to test this functionality